### PR TITLE
fix: remove modal auto-close and remove status log upon close

### DIFF
--- a/src/components/store-deploy-block.tsx
+++ b/src/components/store-deploy-block.tsx
@@ -97,7 +97,7 @@ export const StoreDeployBlock: FunctionComponent<DocumentStoreAddressProps> = ({
         </div>
         <div className="sm:flex pt-5">
           <SecondaryButton onClick={() => clearDeployStatus()} className="w-full mr-5 text-sm font-medium">
-            Cancel
+            Close
           </SecondaryButton>
           <PrimaryButton
             onClick={deployDocumentStore}

--- a/src/components/store-deploy-block.tsx
+++ b/src/components/store-deploy-block.tsx
@@ -39,6 +39,7 @@ export const StoreDeployBlock: FunctionComponent<DocumentStoreAddressProps> = ({
       setProcessing(true);
       const transaction = await deploy(documentStoreName, setLog);
       if (transaction) {
+        setShowModal(true);
         const walletNetwork = await getWalletNetwork();
         const etherscanNetwork = getEtherscanAddress({
           network: walletNetwork,

--- a/src/components/store-deploy-block.tsx
+++ b/src/components/store-deploy-block.tsx
@@ -47,10 +47,14 @@ export const StoreDeployBlock: FunctionComponent<DocumentStoreAddressProps> = ({
           `Document Store Deployed. Find more details at <a href="${etherscanNetwork}/address/${transaction.contractAddress}" target="_blank">${etherscanNetwork}/address/${transaction.contractAddress}</a>.`
         );
         validateStorageAddress(transaction.contractAddress);
-        setShowModal(false);
       }
     }
     setProcessing(false);
+  };
+
+  const clearDeployStatus = () => {
+    setLog("");
+    setShowModal(false);
   };
 
   return (
@@ -91,7 +95,7 @@ export const StoreDeployBlock: FunctionComponent<DocumentStoreAddressProps> = ({
           />
         </div>
         <div className="sm:flex pt-5">
-          <SecondaryButton onClick={() => setShowModal(false)} className="w-full mr-5 text-sm font-medium">
+          <SecondaryButton onClick={() => clearDeployStatus()} className="w-full mr-5 text-sm font-medium">
             Cancel
           </SecondaryButton>
           <PrimaryButton

--- a/src/components/util/deploy.tsx
+++ b/src/components/util/deploy.tsx
@@ -11,7 +11,11 @@ export const deployDocumentStore = async (
     const signer = await getSigner();
     log ? log("Wallet successfully decrypted.") : null;
     const factory = new DocumentStoreFactory(signer);
-    log ? log(`Deploying document store "${storeName}".`) : null;
+    log
+      ? log(
+          `Deploying document store "${storeName}". It may take awhile, You can stay on the page or leave until it's successfully deployed.`
+        )
+      : null;
     const transaction = await factory.deploy(storeName);
     return transaction.deployTransaction.wait();
   } catch (e) {

--- a/src/components/util/deploy.tsx
+++ b/src/components/util/deploy.tsx
@@ -1,6 +1,7 @@
 import { DocumentStoreFactory } from "@govtechsg/document-store";
 import { Dispatch } from "react";
-import { getSigner } from "./wallet";
+import { getEtherscanAddress } from "./common";
+import { getSigner, getWalletNetwork } from "./wallet";
 
 export const deployDocumentStore = async (
   storeName: string,
@@ -11,14 +12,18 @@ export const deployDocumentStore = async (
     const signer = await getSigner();
     log ? log("Wallet successfully decrypted.") : null;
     const factory = new DocumentStoreFactory(signer);
+    const transaction = await factory.deploy(storeName);
+    const transactioHash = transaction.deployTransaction.hash;
+    const etherscanNetwork = getEtherscanAddress({
+      network: await getWalletNetwork(),
+    });
     log
       ? log(
-          `Deploying document store "${storeName}". It may take awhile, You can stay on the page or leave until it's successfully deployed.`
+          `Deploying document store "${storeName}". Waiting for transaction ${transactioHash} to be processed. It may take awhile, You can stay on the page or leave until it's successfully deployed. Find more details at <a href="${etherscanNetwork}/tx/${transactioHash}" target="_blank">${etherscanNetwork}/tx/${transactioHash}</a>. `
         )
       : null;
-    const transaction = await factory.deploy(storeName);
     return transaction.deployTransaction.wait();
-  } catch (e) {
+  } catch (e: any) {
     log ? log(e.message) : null;
   }
 };

--- a/src/components/util/deploy.tsx
+++ b/src/components/util/deploy.tsx
@@ -19,7 +19,7 @@ export const deployDocumentStore = async (
     });
     log
       ? log(
-          `Deploying document store "${storeName}". Waiting for transaction ${transactioHash} to be processed. It may take awhile, You can stay on the page or leave until it's successfully deployed. Find more details at <a href="${etherscanNetwork}/tx/${transactioHash}" target="_blank">${etherscanNetwork}/tx/${transactioHash}</a>. `
+          `Deploying document store "${storeName}". Waiting for transaction ${transactioHash} to be processed. It may take awhile, You can stay on the page or close the popup until it's successfully deployed. Find more details at <a href="${etherscanNetwork}/tx/${transactioHash}" target="_blank">${etherscanNetwork}/tx/${transactioHash}</a>. `
         )
       : null;
     return transaction.deployTransaction.wait();


### PR DESCRIPTION
1. Remove auto-closing after document store created.
2. Clear status log upon closing document store.
3. Added message to allow users to close modal after deploying, 
4. Added modal popup upon deploy transaction complete
5. Added transaction etherscan link into log when deploying document store

Closes #46 , Closes #43, Closes #37